### PR TITLE
Fix wording

### DIFF
--- a/src/code-signing/3_windows.md
+++ b/src/code-signing/3_windows.md
@@ -70,7 +70,7 @@ The primary tool for code signing is SignTool.exe from the Windows SDK, which ca
 
 The digest algorithm defaults to SHA-1. However, you need to use at least SHA-2 for any practical purpose. The most common choice is SHA-256 (SHA-2 algorithm with 256-bit digests). The certificate can be a PFX file or a certificate from a Windows certificate store.
 
-* A PFX file must contain the password. If it contains a password protected private key, the password must be specified using an additional parameter. Alternatively, the private key can be provided by a CSP (see below).
+* A PFX file must contain the private key. If it contains a password protected private key, the password must be specified using an additional parameter. Alternatively, the private key can be provided by a CSP (see below).
 * A certificate can be stored in a certificate store. In this case, you must provide the certificate name or thumbprint. (A certificate from the Windows certificate store  can be chosen automatically, but this is fragile and therefore not recommended.)
 * You can also use a hardware security module through the Windows certificate store.
   

--- a/src/code-signing/3_windows.md
+++ b/src/code-signing/3_windows.md
@@ -108,7 +108,7 @@ Note that hardware keys can still be physically stolen, especially when stored o
 
 ### Microsoft SmartScreen
 
-SmartScreen is a cloud-based system best known for avoiding fishing sites and social engineering attacks. It is also a vital part of Microsoft's anti-malware strategy, a function it performs by checking downloaded software against lists of known programs and certificates.
+SmartScreen is a cloud-based system best known for avoiding phishing sites and social engineering attacks. It is also a vital part of Microsoft's anti-malware strategy, a function it performs by checking downloaded software against lists of known programs and certificates.
 
 | Validation and reputation | Action |
 | ------------------------- | ------ |


### PR DESCRIPTION
Two small fixes of typos/wording.

> A PFX file must contain the password.

I think the author intended to write: "... must contain the **private key**."

>  SmartScreen is a cloud-based system best known for avoiding fishing sites 

I think the spelling "**phishing**" is more common in this context.